### PR TITLE
support empty client_secret in the Authorization header

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/ClientCredentialFetcher.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/ClientCredentialFetcher.scala
@@ -8,11 +8,18 @@ trait ClientCredentialFetcher {
 
   def fetch(request: Request): Option[ClientCredential] = {
     request.header("Authorization").map { authorization =>
-      val decoded = Base64.decodeBase64(authorization.substring(6).getBytes)
-      new String(decoded, "UTF-8").split(":") match {
-        case Array(clientId, clientSecret) => Option(ClientCredential(clientId, clientSecret))
-        case _ => None
+      val decoded = new String(Base64.decodeBase64(authorization.substring(6).getBytes), "UTF-8")
+      if (decoded.indexOf(':') > 0) {
+        decoded.split(":", 2) match {
+          case Array(clientId, clientSecret) => Option(ClientCredential(clientId, clientSecret))
+          case Array(clientId) => Option(ClientCredential(clientId, ""))
+          case _ => None
+        }
+        
+      } else {
+        None
       }
+
     }.getOrElse {
       for {
         clientId <- request.param("client_id")

--- a/scala-oauth2-core/src/test/scala/oauth2/provider/ClientCredentialFetcherSpec.scala
+++ b/scala-oauth2-core/src/test/scala/oauth2/provider/ClientCredentialFetcherSpec.scala
@@ -11,6 +11,13 @@ class ClientCredentialFetcherSpec extends FlatSpec {
     c.clientId should be ("client_id_value")
     c.clientSecret should be ("client_secret_value")
   }
+  
+  it should "fetch empty client_secret" in {
+    val request = Request(Map("Authorization" -> "Basic Y2xpZW50X2lkX3ZhbHVlOg=="), Map())
+    val Some(c) = ClientCredentialFetcher.fetch(request)
+    c.clientId should be ("client_id_value")
+    c.clientSecret should be ("")
+  }
 
   it should "not fetch no Authorization key in header" in {
     val request = Request(Map("authorizatio" -> "Basic Y2xpZW50X2lkX3ZhbHVlOmNsaWVudF9zZWNyZXRfdmFsdWU="), Map())


### PR DESCRIPTION
Fix throwing InvalidRequest Exception when client_secret is an empty string.
