### PR TITLE
Add additional cache control headers per RFC 6749 Section 5.1

### DIFF
--- a/play2-oauth2-provider/src/main/scala/scalaoauth2/provider/OAuth2Provider.scala
+++ b/play2-oauth2-provider/src/main/scala/scalaoauth2/provider/OAuth2Provider.scala
@@ -114,7 +114,7 @@ trait OAuth2Provider extends OAuth2BaseProvider {
     TokenEndpoint.handleRequest(request, dataHandler) match {
       case Left(e) if e.statusCode == 400 => BadRequest(responseOAuthErrorJson(e)).withHeaders(responseOAuthErrorHeader(e))
       case Left(e) if e.statusCode == 401 => Unauthorized(responseOAuthErrorJson(e)).withHeaders(responseOAuthErrorHeader(e))
-      case Right(r) => Ok(Json.toJson(responseAccessToken(r)))
+      case Right(r) => Ok(Json.toJson(responseAccessToken(r))).withHeaders("Cache-Control" -> "no-store", "Pragma" -> "no-cache")
     }
   }
 
@@ -185,7 +185,7 @@ trait OAuth2AsyncProvider extends OAuth2BaseProvider {
     TokenEndpoint.handleRequest(request, dataHandler) match {
       case Left(e) if e.statusCode == 400 => Future.successful(BadRequest(responseOAuthErrorJson(e)).withHeaders(responseOAuthErrorHeader(e)))
       case Left(e) if e.statusCode == 401 => Future.successful(Unauthorized(responseOAuthErrorJson(e)).withHeaders(responseOAuthErrorHeader(e)))
-      case Right(r) => Future.successful(Ok(Json.toJson(responseAccessToken(r))))
+      case Right(r) => Future.successful(Ok(Json.toJson(responseAccessToken(r))).withHeaders("Cache-Control" -> "no-store", "Pragma" -> "no-cache"))
     }
   }
 


### PR DESCRIPTION
http://tools.ietf.org/html/rfc6749#section-5.1

"The authorization server MUST include the HTTP "Cache-Control" response header field [RFC2616] with a value of "no-store" in any response containing tokens, credentials, or other sensitive information, as well as the "Pragma" response header field [RFC2616] with a value of "no-cache"."
