### PR TITLE
When username/password is incorrect gives a more decriptive error message

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -60,7 +60,7 @@ class Password(clientCredentialFetcher: ClientCredentialFetcher) extends GrantHa
     val clientCredential = clientCredentialFetcher.fetch(request).getOrElse(throw new InvalidRequest("BadRequest"))
     val username = request.requireUsername
     val password = request.requirePassword
-    val user = dataHandler.findUser(username, password).getOrElse(throw new InvalidGrant())
+    val user = dataHandler.findUser(username, password).getOrElse(throw new InvalidGrant("username or password is incorrect"))
     val scope = request.scope
     val clientId = clientCredential.clientId
     val authInfo = AuthInfo(user, clientId, scope, None)


### PR DESCRIPTION
When DataHandler.findUser() returns None, (incorrect user/password), Returns InvalidGrant with a more decriptive error message
