### PR TITLE
Add AuthorizationHandler#deleteAuthCode (addresses #65)

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
@@ -6,7 +6,7 @@ import scala.concurrent.Future
  * Provide <b>Authorization</b> phases support for using OAuth 2.0.
  *
  * <h3>[Authorization phases]</h3>
- * 
+ *
  * <h4>Authorization Code Grant</h4>
  * <ul>
  *   <li>validateClient(clientCredential, grantType)</li>
@@ -16,14 +16,14 @@ import scala.concurrent.Future
  *   <li>refreshAccessToken(authInfo, token)
  *   <li>createAccessToken(authInfo)</li>
  * </ul>
- * 
+ *
  * <h4>Refresh Token Grant</h4>
  * <ul>
  *   <li>validateClient(clientCredential, grantType)</li>
  *   <li>findAuthInfoByRefreshToken(refreshToken)</li>
  *   <li>refreshAccessToken(authInfo, refreshToken)</li>
  * </ul>
- * 
+ *
  * <h4>Resource Owner Password Credentials Grant</h4>
  * <ul>
  *   <li>validateClient(clientCredential, grantType)</li>
@@ -33,7 +33,7 @@ import scala.concurrent.Future
  *   <li>refreshAccessToken(authInfo, token)
  *   <li>createAccessToken(authInfo)</li>
  * </ul>
- * 
+ *
  * <h4>Client Credentials Grant</h4>
  * <ul>
  *   <li>validateClient(clientCredential, grantType)</li>
@@ -101,6 +101,18 @@ trait AuthorizationHandler[U] {
    * @return Return authorized information that matched the code.
    */
   def findAuthInfoByCode(code: String): Future[Option[AuthInfo[U]]]
+
+  /**
+   * Deletes an authorization code.
+   *
+   * Called when an AccessToken has been successfully issued via an authorization code.
+   *
+   * If you don't support Authorization Code Grant, then you don't need to implement this
+   * method.
+   *
+   * @param code Client-sent authorization code
+   */
+  def deleteAuthCode(code: String): Future[Unit]
 
   /**
    * Find authorized information by refresh token.

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
@@ -11,9 +11,10 @@ import scala.concurrent.Future
  * <ul>
  *   <li>validateClient(clientCredential, grantType)</li>
  *   <li>findAuthInfoByCode(code)</li>
+ *   <li>deleteAuthCode(code)</li>
  *   <li>getStoredAccessToken(authInfo)</li>
  *   <li>isAccessTokenExpired(token)</li>
- *   <li>refreshAccessToken(authInfo, token)
+ *   <li>refreshAccessToken(authInfo, token)</li>
  *   <li>createAccessToken(authInfo)</li>
  * </ul>
  *
@@ -30,7 +31,7 @@ import scala.concurrent.Future
  *   <li>findUser(username, password)</li>
  *   <li>getStoredAccessToken(authInfo)</li>
  *   <li>isAccessTokenExpired(token)</li>
- *   <li>refreshAccessToken(authInfo, token)
+ *   <li>refreshAccessToken(authInfo, token)</li>
  *   <li>createAccessToken(authInfo)</li>
  * </ul>
  *
@@ -40,7 +41,7 @@ import scala.concurrent.Future
  *   <li>findClientUser(clientCredential)</li>
  *   <li>getStoredAccessToken(authInfo)</li>
  *   <li>isAccessTokenExpired(token)</li>
- *   <li>refreshAccessToken(authInfo, token)
+ *   <li>refreshAccessToken(authInfo, token)</li>
  *   <li>createAccessToken(authInfo)</li>
  * </ul>
  *

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -122,7 +122,9 @@ class AuthorizationCode extends GrantHandler {
         throw new RedirectUriMismatch
       }
 
-      issueAccessToken(handler, authInfo)
+      val fGrantResult = issueAccessToken(handler, authInfo)
+      fGrantResult onSuccess { case _ => handler.deleteAuthCode(code) }
+      fGrantResult
     }
   }
 

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -122,9 +122,9 @@ class AuthorizationCode extends GrantHandler {
         throw new RedirectUriMismatch
       }
 
-      val fGrantResult = issueAccessToken(handler, authInfo)
-      fGrantResult onSuccess { case _ => handler.deleteAuthCode(code) }
-      fGrantResult
+      val f = issueAccessToken(handler, authInfo)
+      f onSuccess { case _ => handler.deleteAuthCode(code) }
+      f
     }
   }
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
@@ -11,6 +11,7 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures {
   it should "handle request" in {
     val authorizationCode = new AuthorizationCode()
     val request = AuthorizationRequest(Map(), Map("code" -> Seq("code1"), "redirect_uri" -> Seq("http://example.com/")))
+    var codeDeleted: Boolean = false
     val f = authorizationCode.handleRequest(request, Some(ClientCredential("clientId1", Some("clientSecret1"))), new MockDataHandler() {
 
       override def findAuthInfoByCode(code: String): Future[Option[AuthInfo[User]]] = Future.successful(Some(
@@ -18,14 +19,20 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures {
       ))
 
       override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("token1", Some("refreshToken1"), Some("all"), Some(3600), new java.util.Date()))
+
+      override def deleteAuthCode(code: String): Future[Unit] = {
+        codeDeleted = true
+        Future.successful(Unit)
+      }
     })
 
     whenReady(f) { result =>
-      result.tokenType should be ("Bearer")
-      result.accessToken should be ("token1")
-      result.expiresIn should be (Some(3600))
-      result.refreshToken should be (Some("refreshToken1"))
-      result.scope should be (Some("all"))
+      codeDeleted shouldBe true
+      result.tokenType shouldBe "Bearer"
+      result.accessToken shouldBe "token1"
+      result.expiresIn shouldBe Some(3600)
+      result.refreshToken shouldBe Some("refreshToken1")
+      result.scope shouldBe Some("all")
     }
   }
 
@@ -42,11 +49,11 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures {
     })
 
     whenReady(f) { result =>
-      result.tokenType should be ("Bearer")
-      result.accessToken should be ("token1")
-      result.expiresIn should be (Some(3600))
-      result.refreshToken should be (Some("refreshToken1"))
-      result.scope should be (Some("all"))
+      result.tokenType shouldBe "Bearer"
+      result.accessToken shouldBe "token1"
+      result.expiresIn shouldBe Some(3600)
+      result.refreshToken shouldBe Some("refreshToken1")
+      result.scope shouldBe Some("all")
     }
   }
 }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
@@ -26,6 +26,7 @@ class MockDataHandler extends DataHandler[User] {
 
   def refreshAccessToken(authInfo: AuthInfo[User], refreshToken: String): Future[AccessToken] = Future.successful(AccessToken("", Some(""), Some(""), Some(0L), new Date()))
 
+  def deleteAuthCode(code: String): Future[Unit] = Future.successful(Unit)
 }
 
 trait User {


### PR DESCRIPTION
This allows us to implement [section 4.1.2](https://tools.ietf.org/html/rfc6749#section-4.1.2)
of the Oauth2 RFC, which states that

> The client MUST NOT use the authorization code more than once.  If an authorization code is used more than once, the authorization server MUST deny the request and SHOULD revoke (when possible) all tokens previously issued based on that authorization code.  The authorization code is bound to the client identifier and redirection URI.

Addresses #65