### PR TITLE
Fix #47: Add implicit grant

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
@@ -45,6 +45,15 @@ import scala.concurrent.Future
  *   <li>createAccessToken(authInfo)</li>
  * </ul>
  *
+ * <h4>Implicit Grant</h4>
+ * <ul>
+ *   <li>findUser(request)</li>
+ *   <li>getStoredAccessToken(authInfo)</li>
+ *   <li>isAccessTokenExpired(token)</li>
+ *   <li>refreshAccessToken(authInfo, token)</li>
+ *   <li>createAccessToken(authInfo)</li>
+ * </ul>
+ *
  */
 trait AuthorizationHandler[U] {
 
@@ -66,6 +75,14 @@ trait AuthorizationHandler[U] {
    * @return Including UserId to Option if could find the user, None if couldn't find.
    */
   def findUser(username: String, password: String): Future[Option[U]]
+
+  /**
+   * Authenticate the user that issued the authorization request.
+   * If you don't support Implicit Grant, then doesn't need implementing.
+   *
+   * @oaram request Request sent by client.
+   */
+  def findUser(request: AuthorizationRequest): Future[Option[U]]
 
   /**
    * Creates a new access token by authorized information.

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -129,3 +129,19 @@ class AuthorizationCode extends GrantHandler {
   }
 
 }
+
+class Implicit extends GrantHandler {
+
+  override def handleRequest[U](request: AuthorizationRequest, maybeClientCredential: Option[ClientCredential], handler: AuthorizationHandler[U]): Future[GrantHandlerResult] = {
+    val clientId = request.clientId.getOrElse(throw new InvalidRequest("Client id is required"))
+
+    handler.findUser(request).flatMap { userOption =>
+      val user = userOption.getOrElse(throw new InvalidGrant("user cannot be authenticated"))
+      val scope = request.scope
+      val authInfo = AuthInfo(user, Some(clientId), scope, None)
+
+      issueAccessToken(handler, authInfo)
+    }
+  }
+
+}

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
@@ -12,7 +12,8 @@ trait TokenEndpoint {
     AUTHORIZATION_CODE  -> new AuthorizationCode(),
     REFRESH_TOKEN       -> new RefreshToken(),
     CLIENT_CREDENTIALS  -> new ClientCredentials(),
-    PASSWORD            -> new Password()
+    PASSWORD            -> new Password(),
+    IMPLICIT            -> new Implicit()
   )
 
   def handleRequest[U](request: AuthorizationRequest, handler: AuthorizationHandler[U]): Future[Either[OAuthError, GrantHandlerResult]] = try {

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/package.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/package.scala
@@ -7,6 +7,7 @@ package object provider {
     val REFRESH_TOKEN = "refresh_token"
     val CLIENT_CREDENTIALS = "client_credentials"
     val PASSWORD = "password"
+    val IMPLICIT = "implicit"
   }
 
 }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
@@ -1,0 +1,42 @@
+package scalaoauth2.provider
+
+import org.scalatest._
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.Future
+
+class ImplicitSpec extends FlatSpec with ScalaFutures {
+
+  val implicitGrant = new Implicit()
+
+  "Implicit" should "grant access with valid user authentication" in handlesRequest(implicitGrant, "user", "pass", true)
+  "Implicit" should "not grant access with invalid user authentication" in handlesRequest(implicitGrant, "user", "wrong_pass", false)
+
+  def handlesRequest(implicitGrant: Implicit, user: String, pass: String, ok: Boolean) = {
+    val request = AuthorizationRequest(Map(), Map("client_id" -> Seq("client"), "username" -> Seq(user), "password" -> Seq(pass), "scope" -> Seq("all")))
+    val f = implicitGrant.handleRequest(request, None, new MockDataHandler() {
+
+      override def findUser(request: AuthorizationRequest): Future[Option[User]] =
+        Future.successful(if(request.requireUsername == "user" && request.requirePassword == "pass") Some(MockUser(10000, "username")) else None)
+
+      override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] =
+        Future.successful(AccessToken("token1", None, Some("all"), Some(3600), new java.util.Date()))
+
+    })
+
+    if(ok) {
+      whenReady(f) { result =>
+        result.tokenType should be("Bearer")
+        result.accessToken should be("token1")
+        result.expiresIn should be(Some(3600))
+        result.refreshToken should be(None)
+        result.scope should be(Some("all"))
+      }
+    } else {
+      whenReady(f.failed) { e =>
+        e shouldBe an[InvalidGrant]
+      }
+    }
+  }
+}

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
@@ -10,6 +10,8 @@ class MockDataHandler extends DataHandler[User] {
 
   def findUser(username: String, password: String): Future[Option[User]] = Future.successful(None)
 
+  def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(None)
+
   def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("", Some(""), Some(""), Some(0L), new Date()))
 
   def findAuthInfoByCode(code: String): Future[Option[AuthInfo[User]]] = Future.successful(None)


### PR DESCRIPTION
Implementation of the implicit grant.

The handler that receives a request must find the user by authenticating
him in any way the application requires it.
The user authentication is done using the received grant request with
all headers and parameters.