### PR TITLE
Make "expires_in" represent seconds of validity since 'now'

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/DataHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/DataHandler.scala
@@ -13,16 +13,21 @@ trait DataHandler[U] extends AuthorizationHandler[U] with ProtectedResourceHandl
  * @param token Access token is used to authentication.
  * @param refreshToken Refresh token is used to re-issue access token.
  * @param scope Inform the client of the scope of the access token issued.
- * @param expiresIn Expiration date of access token. Unit is seconds.
+ * @param lifeSeconds Life of the access token since its creation. In seconds.
  * @param createdAt Access token is created date.
  */
-case class AccessToken(token: String, refreshToken: Option[String], scope: Option[String], expiresIn: Option[Long], createdAt: Date) {
-
-  def isExpired: Boolean = expiresIn.exists { expiresIn =>
-    val now = System.currentTimeMillis()
-    createdAt.getTime + expiresIn * 1000 <= now
+case class AccessToken(token: String, refreshToken: Option[String], scope: Option[String], lifeSeconds: Option[Long], createdAt: Date) {
+  def isExpired: Boolean = expirationTimeInMilis.exists {expTime =>
+    expTime <= System.currentTimeMillis
   }
 
+  def expiresIn: Option[Long] = expirationTimeInMilis map {expTime =>
+    (expTime - System.currentTimeMillis) / 1000
+  }
+
+  private def expirationTimeInMilis: Option[Long] = lifeSeconds map {lifeSecs =>
+    createdAt.getTime + lifeSecs * 1000
+  }
 }
 
 /**

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 
-class AuthorizationCodeSpec extends FlatSpec with ScalaFutures {
+class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   it should "handle request" in {
     val authorizationCode = new AuthorizationCode()
@@ -30,7 +30,7 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures {
       codeDeleted shouldBe true
       result.tokenType shouldBe "Bearer"
       result.accessToken shouldBe "token1"
-      result.expiresIn shouldBe Some(3600)
+      result.expiresIn.value should (be <= 3600L and be > 3595L)
       result.refreshToken shouldBe Some("refreshToken1")
       result.scope shouldBe Some("all")
     }
@@ -51,7 +51,7 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures {
     whenReady(f) { result =>
       result.tokenType shouldBe "Bearer"
       result.accessToken shouldBe "token1"
-      result.expiresIn shouldBe Some(3600)
+      result.expiresIn.value should (be <= 3600L and be > 2595L)
       result.refreshToken shouldBe Some("refreshToken1")
       result.scope shouldBe Some("all")
     }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 
-class ClientCredentialsSpec extends FlatSpec with ScalaFutures {
+class ClientCredentialsSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   it should "handle request" in {
     val clientCredentials = new ClientCredentials()
@@ -21,7 +21,7 @@ class ClientCredentialsSpec extends FlatSpec with ScalaFutures {
     whenReady(f) { result =>
       result.tokenType should be ("Bearer")
       result.accessToken should be ("token1")
-      result.expiresIn should be (Some(3600))
+      result.expiresIn.value should (be <= 3600L and be > 3595L)
       result.refreshToken should be (None)
       result.scope should be (Some("all"))
     }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 
-class ImplicitSpec extends FlatSpec with ScalaFutures {
+class ImplicitSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   val implicitGrant = new Implicit()
 
@@ -29,7 +29,7 @@ class ImplicitSpec extends FlatSpec with ScalaFutures {
       whenReady(f) { result =>
         result.tokenType should be("Bearer")
         result.accessToken should be("token1")
-        result.expiresIn should be(Some(3600))
+        result.expiresIn.value should (be <= 3600L and be > 3595L)
         result.refreshToken should be(None)
         result.scope should be(Some("all"))
       }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 
-class PasswordSpec extends FlatSpec with ScalaFutures {
+class PasswordSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   val passwordClientCredReq = new Password()
   val passwordNoClientCredReq = new Password() {
@@ -29,7 +29,7 @@ class PasswordSpec extends FlatSpec with ScalaFutures {
     whenReady(f) { result =>
       result.tokenType should be("Bearer")
       result.accessToken should be("token1")
-      result.expiresIn should be(Some(3600))
+      result.expiresIn.value should (be <= 3600L and be > 3595L)
       result.refreshToken should be(Some("refreshToken1"))
       result.scope should be(Some("all"))
     }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/RefreshTokenSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/RefreshTokenSpec.scala
@@ -1,12 +1,12 @@
 package scalaoauth2.provider
 
-import org.scalatest.FlatSpec
+import org.scalatest.{FlatSpec, OptionValues}
 import org.scalatest.Matchers._
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Future
 
-class RefreshTokenSpec extends FlatSpec with ScalaFutures {
+class RefreshTokenSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   it should "handle request" in {
     val refreshToken = new RefreshToken()
@@ -23,7 +23,7 @@ class RefreshTokenSpec extends FlatSpec with ScalaFutures {
     whenReady(f) { result =>
       result.tokenType should be ("Bearer")
       result.accessToken should be ("token1")
-      result.expiresIn should be (Some(3600))
+      result.expiresIn.value should (be <= 3600L and be > 3595L)
       result.refreshToken should be (Some("refreshToken1"))
       result.scope should be (None)
     }


### PR DESCRIPTION
This fix makes the expires_in field of an access token actually represent the token's life from now (as opposed to since its time of creation).

In other words, now, if you keep asking for the same access token from the server, you will notice that the "expires_in" field of the json keeps decreasing in value.