### PR TITLE
Error Status code RFC alignment

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -8,7 +8,8 @@ case class GrantHandlerResult[U](
   accessToken: String,
   expiresIn: Option[Long],
   refreshToken: Option[String],
-  scope: Option[String])
+  scope: Option[String]
+)
 
 trait GrantHandler {
   /**

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/OAuthException.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/OAuthException.scala
@@ -20,13 +20,13 @@ class InvalidClient(description: String = "") extends OAuthError(401, descriptio
 
 }
 
-class UnauthorizedClient(description: String = "") extends OAuthError(401, description) {
+class UnauthorizedClient(description: String = "") extends OAuthError(description) {
 
   override val errorType = "unauthorized_client"
 
 }
 
-class RedirectUriMismatch(description: String = "") extends OAuthError(401, description) {
+class RedirectUriMismatch(description: String = "") extends OAuthError(description) {
 
   override val errorType = "redirect_uri_mismatch"
 
@@ -44,7 +44,7 @@ class UnsupportedResponseType(description: String = "") extends OAuthError(descr
 
 }
 
-class InvalidGrant(description: String = "") extends OAuthError(401, description) {
+class InvalidGrant(description: String = "") extends OAuthError(description) {
 
   override val errorType = "invalid_grant"
 
@@ -56,7 +56,7 @@ class UnsupportedGrantType(description: String = "") extends OAuthError(descript
 
 }
 
-class InvalidScope(description: String = "") extends OAuthError(401, description) {
+class InvalidScope(description: String = "") extends OAuthError(description) {
 
   override val errorType = "invalid_scope"
 
@@ -74,7 +74,7 @@ class ExpiredToken() extends OAuthError(401, "The access token expired") {
 
 }
 
-class InsufficientScope(description: String = "") extends OAuthError(401, description) {
+class InsufficientScope(description: String = "") extends OAuthError(403, description) {
 
   override val errorType = "insufficient_scope"
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/OAuthErrorsSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/OAuthErrorsSpec.scala
@@ -1,0 +1,51 @@
+package scalaoauth2.provider
+
+import org.scalatest.Matchers._
+import org.scalatest._
+
+class OAuthErrorsSpec extends FlatSpec {
+
+  behavior of "OAuth Error Handling RFC 6749 Section 5.2"
+
+  it should "produce a 400 status code for invalid_request" in {
+    new InvalidRequest().statusCode should be(400)
+  }
+
+  it should "produce a 401 status code for invalid_client" in {
+    new InvalidClient().statusCode should be(401)
+  }
+
+  it should "produce a 400 status code for invalid_grant" in {
+    new InvalidGrant().statusCode should be(400)
+  }
+
+  it should "produce a 400 status code for unauthorized_client" in {
+    new UnauthorizedClient().statusCode should be(400)
+  }
+
+  it should "produce a 400 status code for unsupported_grant_type" in {
+    new UnsupportedGrantType().statusCode should be(400)
+  }
+
+  it should "produce a 400 status code for invalid_scope" in {
+    new InvalidScope().statusCode should be(400)
+  }
+
+  it should "produce a 400 status code for redirect_uri_mismatch" in {
+    new RedirectUriMismatch().statusCode should be(400)
+  }
+
+  behavior of "OAuth Error Handling for Bearer Tokens RFC 6750 Section 3.1"
+
+  it should "produce a 400 status code for invalid_request" in {
+    new InvalidRequest().statusCode should be(400)
+  }
+
+  it should "produce a 401 status code for invalid_token" in {
+    new InvalidToken().statusCode should be(401)
+  }
+
+  it should "produce a 403 status code for insufficient_scope" in {
+    new InsufficientScope().statusCode should be(403)
+  }
+}


### PR DESCRIPTION
We recently noticed that some of our tests were failing against the RFC spec with some of the errors returned. Further investigation showed us that the status codes being returned did not align with the RFC. This PR should correct that alignment with tests to keep a regression from happening in the future.

Note: I did not address status codes for Section 4.1.2.1 of the spec - those probably don't even have status codes as they should be part of the redirect URL for the Authorization Grant flow

Regardless, here is what I updated and wrote tests for:

According to RFC 6749 Section 5.2: https://tools.ietf.org/html/rfc6749#section-5.2:

invalid_request: 400
invalid_grant: 400
unauthorized_client: 400
unsupported_grant_type: 400,
invalid_scope: 400
invalid_client: 401

According to RFC 6750 Section 3.1:  https://tools.ietf.org/html/rfc6750#section-3.1

invalid_request: 400
invalid_token: 401
insufficient_scope: 403

redirect_uri_mismatch was not in the standard RFC - but many other companies use it. Following the HTTP status code standard of 6749 Section 5.2 this should be a 400 - because it is a bad request and if corrected, the request would work. From the little I looked into this, it seems others are also returning a 400 here, not a 401.