### PR TITLE
Give the AuthorizationCode GrantHandler more flow control with andThen

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -123,8 +123,7 @@ class AuthorizationCode extends GrantHandler {
       }
 
       val f = issueAccessToken(handler, authInfo)
-      f onSuccess { case _ => handler.deleteAuthCode(code) }
-      f
+      f andThen { case _ => handler.deleteAuthCode(code) }
     }
   }
 


### PR DESCRIPTION
In our application we create a database connection / transaction per endpoint. I noticed a race condition where occasionally the database connection would be closed before `handler.deleteAuthCode(code)` would fire even though I was blocking on the returned future from the DataHandler. Using `onSuccess` doesn't give us the ability to block until the `handler.deleteAuthCode(code)` fires but by using `andThen` we do have the ability to block when both operations are complete.