### PR TITLE
Give the AuthorizationCode GrantHandler more flow control with flatMap

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -123,8 +123,10 @@ class AuthorizationCode extends GrantHandler {
       }
 
       val f = issueAccessToken(handler, authInfo)
-      f onSuccess { case _ => handler.deleteAuthCode(code) }
-      f
+      for {
+        accessToken <- f
+        deleteResult <- handler.deleteAuthCode(code)
+      } yield accessToken
     }
   }
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
@@ -72,7 +72,7 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
       override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("token1", Some("refreshToken1"), Some("all"), Some(3600), new java.util.Date()))
 
       override def deleteAuthCode(code: String): Future[Unit] = {
-        Future.failed[Unit](new Exception())
+        Future.failed(new Exception())
       }
     })
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
@@ -3,6 +3,7 @@ package scalaoauth2.provider
 import org.scalatest.Matchers._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time._
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -22,12 +23,13 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
       override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("token1", Some("refreshToken1"), Some("all"), Some(3600), new java.util.Date()))
 
       override def deleteAuthCode(code: String): Future[Unit] = {
+        Thread.sleep(300)
         codeDeleted = true
         Future.successful(Unit)
       }
     })
 
-    whenReady(f) { result =>
+    whenReady(f, timeout(Span(1, Seconds)), interval(Span(50, Millis))) { result =>
       codeDeleted shouldBe true
       result.tokenType shouldBe "Bearer"
       result.accessToken shouldBe "token1"


### PR DESCRIPTION
In our application we create a database connection / transaction per endpoint. I noticed a race condition where occasionally the database connection would be closed before handler.deleteAuthCode(code) would fire even though I was blocking on the returned future from the DataHandler. Using onSuccess doesn't give us the ability to block until the handler.deleteAuthCode(code) fires but by using andThen we do have the ability to block when both operations are complete.


fixes https://github.com/nulab/scala-oauth2-provider/pull/89
replaces https://github.com/nulab/scala-oauth2-provider/pull/88