### PR TITLE
remove commons-codec from dependency

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,8 @@ object ScalaOAuth2Build extends Build {
   val _crossScalaVersions = Seq("2.11.8")
 
   val commonDependenciesInTestScope = Seq(
-    "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+    "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+    "ch.qos.logback" % "logback-classic" % "1.1.7" % "test"
   )
 
   lazy val scalaOAuth2ProviderSettings =
@@ -46,9 +47,7 @@ object ScalaOAuth2Build extends Build {
     settings = scalaOAuth2ProviderSettings ++ Seq(
       name := "scala-oauth2-core",
       description := "OAuth 2.0 server-side implementation written in Scala",
-      libraryDependencies ++= Seq(
-        "commons-codec" % "commons-codec" % "1.8"
-      ) ++ commonDependenciesInTestScope
+      libraryDependencies ++= commonDependenciesInTestScope
     )
   )
 

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationRequest.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationRequest.scala
@@ -1,50 +1,39 @@
 package scalaoauth2.provider
 
-import org.apache.commons.codec.binary.Base64
+import java.util.Base64
+
+import scala.util.Try
 
 case class ClientCredential(clientId: String, clientSecret: Option[String])
 
 class AuthorizationRequest(headers: Map[String, Seq[String]], params: Map[String, Seq[String]]) extends RequestBase(headers, params) {
 
-  /**
-   * Returns grant_type.
-   *
-   * OAuth defines four grant types:
-   * authorization code
-   * implicit
-   * resource owner password credentials, and client credentials.
-   *
-   * @return grant_type
-   */
-  def grantType: String = requireParam("grant_type")
-
-  /**
-   * Returns scope.
-   *
-   * @return scope
-   */
   def scope: Option[String] = param("scope")
 
-  lazy val clientCredential: Option[ClientCredential] = {
-    header("Authorization").flatMap {
-      """^\s*Basic\s+(.+?)\s*$""".r.findFirstMatchIn
-    } match {
-      case Some(matcher) =>
-        val authorization = matcher.group(1)
-        val decoded = new String(Base64.decodeBase64(authorization.getBytes), "UTF-8")
-        if (decoded.indexOf(':') > 0) {
-          decoded.split(":", 2) match {
-            case Array(clientId, clientSecret) => Some(ClientCredential(clientId, if (clientSecret == "") None else Some(clientSecret)))
-            case Array(clientId) => Some(ClientCredential(clientId, None))
-          }
-        } else {
+  def grantType: String = requireParam("grant_type")
+
+  lazy val clientCredential: Option[ClientCredential] =
+    findAuthorization
+      .flatMap(clientCredentialByAuthorization)
+      .orElse(clientCredentialByParam)
+
+  private def findAuthorization = for {
+    authorization <- header("Authorization")
+    matcher <- """^\s*Basic\s+(.+?)\s*$""".r.findFirstMatchIn(authorization)
+  } yield matcher.group(1)
+
+  private def clientCredentialByAuthorization(s: String) =
+    Try(new String(Base64.getDecoder.decode(s), "UTF-8"))
+      .map(_.split(":", 2))
+      .getOrElse(Array.empty) match {
+        case Array(clientId, clientSecret) =>
+          Some(ClientCredential(clientId, if (clientSecret.isEmpty) None else Some(clientSecret)))
+        case _ =>
           None
-        }
-      case _ => param("client_id").map { clientId =>
-        ClientCredential(clientId, param("client_secret"))
       }
-    }
-  }
+
+  private def clientCredentialByParam = param("client_id").map(ClientCredential(_, param("client_secret")))
+
 }
 
 case class RefreshTokenRequest(request: AuthorizationRequest) extends AuthorizationRequest(request.headers, request.params) {


### PR DESCRIPTION
Currently scala-oauth2-provider supports Java8.
Java8 already has [Base64 library](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html).

We can remove commons-codec for Base64.
In additional, I refactored `AuthorizationRequest.scala`.