### PR TITLE
Avoid response where 'expiresIn' could be negative

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/DataHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/DataHandler.scala
@@ -18,11 +18,9 @@ trait DataHandler[U] extends AuthorizationHandler[U] with ProtectedResourceHandl
  * @param params Additional parameters to add information/restriction on given Access token.
  */
 case class AccessToken(token: String, refreshToken: Option[String], scope: Option[String], lifeSeconds: Option[Long], createdAt: Date, params: Map[String, String] = Map.empty[String, String]) {
-  def isExpired: Boolean = expirationTimeInMilis.exists { expTime =>
-    expTime <= System.currentTimeMillis
-  }
+  def isExpired: Boolean = expiresIn.exists(_ < 0)
 
-  def expiresIn: Option[Long] = expirationTimeInMilis map { expTime =>
+  val expiresIn: Option[Long] = expirationTimeInMilis map { expTime =>
     (expTime - System.currentTimeMillis) / 1000
   }
 


### PR DESCRIPTION
Hello,

In the current process, it is first checked that a `token.isExpired` and then, the `token.expiresIn` is recalculated with a new time. 
As such, it is possible to have a negative value. 

