### PR TITLE
Redirect Uri Mismatch error alignment with specification

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/OAuthException.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/OAuthException.scala
@@ -26,9 +26,9 @@ class UnauthorizedClient(description: String = "") extends OAuthError(descriptio
 
 }
 
-class RedirectUriMismatch(description: String = "") extends OAuthError(description) {
+class RedirectUriMismatch(description: String = "redirect_uri_mismatch") extends OAuthError(description) {
 
-  override val errorType = "redirect_uri_mismatch"
+  override val errorType = "invalid_request"
 
 }
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/OAuthErrorsSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/OAuthErrorsSpec.scala
@@ -32,7 +32,9 @@ class OAuthErrorsSpec extends FlatSpec {
   }
 
   it should "produce a 400 status code for redirect_uri_mismatch" in {
-    new RedirectUriMismatch().statusCode should be(400)
+    val error = new RedirectUriMismatch()
+    error.statusCode should be(400)
+    error.errorType should be("invalid_request")
   }
 
   behavior of "OAuth Error Handling for Bearer Tokens RFC 6750 Section 3.1"


### PR DESCRIPTION
Currently, the RedirectUriMismatch error is using a non-standard errorType. Google popularized this error, but it is not part of the standard specification.

Section 4.1.2.1 specifically states (https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
` If the request fails due to a missing, invalid, or mismatching redirection URI …`
and the valid error types listed that can be returned does not include `redirect_uri_mismatch`.

I propose of the errors listed, the one that makes the most sense is `invalid_request` additionally, we can use the `error_description` field which is optional to provide the existing message of `redirect_uri_mismatch` so the developer knows what he / she did wrong.