### PR TITLE
Authorization Header Specification fixes

### DIFF
--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
@@ -55,6 +55,9 @@ trait AuthorizationHandler[U] {
 
   /**
    * Verify proper client with parameters for issue an access token.
+   * Note that per the OAuth Specification, a Client may be valid if it only contains a client ID but no client
+   * secret (common with Public Clients). However, if the registered client has a client secret value the specification
+   * requires that a client secret must always be provided and verified for that client ID.
    *
    * @param request Request sent by client.
    * @return true if request is a regular client, false if request is a illegal client.

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationRequest.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationRequest.scala
@@ -12,24 +12,32 @@ class AuthorizationRequest(headers: Map[String, Seq[String]], params: Map[String
 
   def grantType: String = requireParam("grant_type")
 
-  lazy val clientCredential: Option[ClientCredential] =
+  lazy val clientCredential: Option[Either[InvalidClient, ClientCredential]] =
     findAuthorization
-      .flatMap(clientCredentialByAuthorization)
-      .orElse(clientCredentialByParam)
+      .flatMap(x => Some(x.fold(
+        left => Left(left),
+        header => clientCredentialByAuthorization(header)
+      )))
+      .orElse(clientCredentialByParam.map(Right(_)))
 
-  private def findAuthorization = for {
-    authorization <- header("Authorization")
-    matcher <- """^\s*Basic\s+(.+?)\s*$""".r.findFirstMatchIn(authorization)
-  } yield matcher.group(1)
+  private def findAuthorization: Option[Either[InvalidClient, String]] = {
+    header("Authorization").map { auth =>
+      val basicAuthCred = for {
+        matcher <- """^\s*Basic\s+(.+?)\s*$""".r.findFirstMatchIn(auth)
+      } yield matcher.group(1)
 
-  private def clientCredentialByAuthorization(s: String) =
+      basicAuthCred.fold[Either[InvalidClient, String]](Left(new InvalidClient("Authorization header could not be parsed")))(x => Right(x))
+    }
+  }
+
+  private def clientCredentialByAuthorization(s: String): Either[InvalidClient, ClientCredential] =
     Try(new String(Base64.getDecoder.decode(s), "UTF-8"))
       .map(_.split(":", 2))
       .getOrElse(Array.empty) match {
         case Array(clientId, clientSecret) =>
-          Some(ClientCredential(clientId, if (clientSecret.isEmpty) None else Some(clientSecret)))
+          Right(ClientCredential(clientId, if (clientSecret.isEmpty) None else Some(clientSecret)))
         case _ =>
-          None
+          Left(new InvalidClient())
       }
 
   private def clientCredentialByParam = param("client_id").map(ClientCredential(_, param("client_secret")))
@@ -44,8 +52,6 @@ case class RefreshTokenRequest(request: AuthorizationRequest) extends Authorizat
    * @throws InvalidRequest if the parameter is not found
    */
   def refreshToken: String = requireParam("refresh_token")
-
-  override lazy val clientCredential = request.clientCredential
 }
 
 case class PasswordRequest(request: AuthorizationRequest) extends AuthorizationRequest(request.headers, request.params) {
@@ -64,13 +70,9 @@ case class PasswordRequest(request: AuthorizationRequest) extends AuthorizationR
    * @throws InvalidRequest if the parameter is not found
    */
   def password = requireParam("password")
-
-  override lazy val clientCredential = request.clientCredential
 }
 
-case class ClientCredentialsRequest(request: AuthorizationRequest) extends AuthorizationRequest(request.headers, request.params) {
-  override lazy val clientCredential = request.clientCredential
-}
+case class ClientCredentialsRequest(request: AuthorizationRequest) extends AuthorizationRequest(request.headers, request.params)
 
 case class AuthorizationCodeRequest(request: AuthorizationRequest) extends AuthorizationRequest(request.headers, request.params) {
   /**
@@ -87,11 +89,6 @@ case class AuthorizationCodeRequest(request: AuthorizationRequest) extends Autho
    * @return redirect_uri
    */
   def redirectUri: Option[String] = param("redirect_uri")
-
-  override lazy val clientCredential = request.clientCredential
-
 }
 
-case class ImplicitRequest(request: AuthorizationRequest) extends AuthorizationRequest(request.headers, request.params) {
-  override lazy val clientCredential = request.clientCredential
-}
+case class ImplicitRequest(request: AuthorizationRequest) extends AuthorizationRequest(request.headers, request.params)

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationRequest.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationRequest.scala
@@ -12,7 +12,7 @@ class AuthorizationRequest(headers: Map[String, Seq[String]], params: Map[String
 
   def grantType: String = requireParam("grant_type")
 
-  lazy val clientCredential: Option[Either[InvalidClient, ClientCredential]] =
+  def parseClientCredential: Option[Either[InvalidClient, ClientCredential]] =
     findAuthorization
       .flatMap(x => Some(x.fold(
         left => Left(left),

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
@@ -9,7 +9,7 @@ trait TokenEndpoint {
     val grantType = request.grantType
     val grantHandler = () => handlers.getOrElse(grantType, throw new UnsupportedGrantType(s"$grantType is not supported"))
 
-    request.clientCredential.map { maybeCredential =>
+    request.parseClientCredential.map { maybeCredential =>
       maybeCredential.fold(
         invalid => Future.successful(Left(invalid)),
         clientCredential => {
@@ -17,7 +17,7 @@ trait TokenEndpoint {
             if (!isValidClient) {
               Future.successful(Left(new InvalidClient("Invalid client or client is not authorized")))
             } else {
-              grantHandler().handleRequest(Some(clientCredential.clientId), request, handler).map(Right(_))
+              grantHandler().handleRequest(Some(clientCredential), request, handler).map(Right(_))
             }
           }.recover {
             case e: OAuthError => Left(e)

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
@@ -7,23 +7,29 @@ trait TokenEndpoint {
 
   def handleRequest[U](request: AuthorizationRequest, handler: AuthorizationHandler[U])(implicit ctx: ExecutionContext): Future[Either[OAuthError, GrantHandlerResult[U]]] = try {
     val grantType = request.grantType
-    val grantHandler = handlers.getOrElse(grantType, throw new UnsupportedGrantType(s"${grantType} is not supported"))
+    val grantHandler = () => handlers.getOrElse(grantType, throw new UnsupportedGrantType(s"$grantType is not supported"))
 
-    request.clientCredential.map { clientCredential =>
-      handler.validateClient(request).flatMap { validClient =>
-        if (!validClient) {
-          Future.successful(Left(new InvalidClient("Invalid client is detected")))
-        } else {
-          grantHandler.handleRequest(request, handler).map(Right(_))
+    request.clientCredential.map { maybeCredential =>
+      maybeCredential.fold(
+        invalid => Future.successful(Left(invalid)),
+        clientCredential => {
+          handler.validateClient(request).flatMap { isValidClient =>
+            if (!isValidClient) {
+              Future.successful(Left(new InvalidClient("Invalid client or client is not authorized")))
+            } else {
+              grantHandler().handleRequest(Some(clientCredential.clientId), request, handler).map(Right(_))
+            }
+          }.recover {
+            case e: OAuthError => Left(e)
+          }
         }
-      }.recover {
-        case e: OAuthError => Left(e)
-      }
+      )
     }.getOrElse {
-      if (grantHandler.clientCredentialRequired) {
+      val gh = grantHandler()
+      if (gh.clientCredentialRequired) {
         throw new InvalidRequest("Client credential is not found")
       } else {
-        grantHandler.handleRequest(request, handler).map(Right(_)).recover {
+        gh.handleRequest(None, request, handler).map(Right(_)).recover {
           case e: OAuthError => Left(e)
         }
       }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
@@ -14,7 +14,8 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
     val authorizationCode = new AuthorizationCode()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "code" -> Seq("code1"), "redirect_uri" -> Seq("http://example.com/")))
     var codeDeleted: Boolean = false
-    val f = authorizationCode.handleRequest(request, new MockDataHandler() {
+    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
+    val f = authorizationCode.handleRequest(clientId, request, new MockDataHandler() {
 
       override def findAuthInfoByCode(code: String): Future[Option[AuthInfo[User]]] = Future.successful(Some(
         AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = Some("all"), redirectUri = Some("http://example.com/"))
@@ -42,7 +43,8 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
   it should "handle request if redirectUrl is none" in {
     val authorizationCode = new AuthorizationCode()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "code" -> Seq("code1"), "redirect_uri" -> Seq("http://example.com/")))
-    val f = authorizationCode.handleRequest(request, new MockDataHandler() {
+    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
+    val f = authorizationCode.handleRequest(clientId, request, new MockDataHandler() {
 
       override def findAuthInfoByCode(code: String): Future[Option[AuthInfo[MockUser]]] = Future.successful(Some(
         AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = Some("all"), redirectUri = None)
@@ -63,7 +65,8 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
   it should "return a Failure Future" in {
     val authorizationCode = new AuthorizationCode()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "code" -> Seq("code1"), "redirect_uri" -> Seq("http://example.com/")))
-    val f = authorizationCode.handleRequest(request, new MockDataHandler() {
+    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
+    val f = authorizationCode.handleRequest(clientId, request, new MockDataHandler() {
 
       override def findAuthInfoByCode(code: String): Future[Option[AuthInfo[User]]] = Future.successful(Some(
         AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = Some("all"), redirectUri = Some("http://example.com/"))

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationCodeSpec.scala
@@ -14,8 +14,8 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
     val authorizationCode = new AuthorizationCode()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "code" -> Seq("code1"), "redirect_uri" -> Seq("http://example.com/")))
     var codeDeleted: Boolean = false
-    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
-    val f = authorizationCode.handleRequest(clientId, request, new MockDataHandler() {
+    val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val f = authorizationCode.handleRequest(clientCred, request, new MockDataHandler() {
 
       override def findAuthInfoByCode(code: String): Future[Option[AuthInfo[User]]] = Future.successful(Some(
         AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = Some("all"), redirectUri = Some("http://example.com/"))
@@ -43,8 +43,8 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
   it should "handle request if redirectUrl is none" in {
     val authorizationCode = new AuthorizationCode()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "code" -> Seq("code1"), "redirect_uri" -> Seq("http://example.com/")))
-    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
-    val f = authorizationCode.handleRequest(clientId, request, new MockDataHandler() {
+    val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val f = authorizationCode.handleRequest(clientCred, request, new MockDataHandler() {
 
       override def findAuthInfoByCode(code: String): Future[Option[AuthInfo[MockUser]]] = Future.successful(Some(
         AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = Some("all"), redirectUri = None)
@@ -65,8 +65,8 @@ class AuthorizationCodeSpec extends FlatSpec with ScalaFutures with OptionValues
   it should "return a Failure Future" in {
     val authorizationCode = new AuthorizationCode()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "code" -> Seq("code1"), "redirect_uri" -> Seq("http://example.com/")))
-    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
-    val f = authorizationCode.handleRequest(clientId, request, new MockDataHandler() {
+    val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val f = authorizationCode.handleRequest(clientCred, request, new MockDataHandler() {
 
       override def findAuthInfoByCode(code: String): Future[Option[AuthInfo[User]]] = Future.successful(Some(
         AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = Some("all"), redirectUri = Some("http://example.com/"))

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationRequestSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationRequestSpec.scala
@@ -1,32 +1,33 @@
 package scalaoauth2.provider
 
 import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.Matchers.{ an, _ }
 
 class AuthorizationRequestSpec extends FlatSpec {
 
   it should "fetch Basic64" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOmNsaWVudF9zZWNyZXRfdmFsdWU=")), Map())
-    val Some(c) = request.clientCredential
+    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(Some("client_secret_value"))
   }
 
   it should "fetch Basic64 by case insensitive" in {
     val request = new AuthorizationRequest(Map("authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOmNsaWVudF9zZWNyZXRfdmFsdWU=")), Map())
-    val Some(c) = request.clientCredential
+    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(Some("client_secret_value"))
   }
 
   it should "fetch authorization header without colon" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVl")), Map())
-    request.clientCredential should be(None)
+    request.clientCredential.isDefined shouldBe true
+    request.clientCredential.get.isLeft shouldBe true
   }
 
   it should "fetch empty client_secret with colon" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOg==")), Map())
-    val Some(c) = request.clientCredential
+    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(None)
   }
@@ -38,19 +39,20 @@ class AuthorizationRequestSpec extends FlatSpec {
 
   it should "not fetch invalid Base64" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic basic")), Map())
-    request.clientCredential should be(None)
+    request.clientCredential.isDefined shouldBe true
+    request.clientCredential.get.isLeft shouldBe true
   }
 
   it should "fetch parameter" in {
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("client_id_value"), "client_secret" -> Seq("client_secret_value")))
-    val Some(c) = request.clientCredential
+    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(Some("client_secret_value"))
   }
 
   it should "omit client_secret" in {
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("client_id_value")))
-    val Some(c) = request.clientCredential
+    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(None)
   }
@@ -62,16 +64,22 @@ class AuthorizationRequestSpec extends FlatSpec {
 
   it should "not fetch invalid parameter" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("")), Map())
-    request.clientCredential should be(None)
+    request.clientCredential.isDefined shouldBe true
+    request.clientCredential.get.isLeft shouldBe true
   }
 
-  it should "fetch parameter with invalid header" in {
+  it should "not fetch invalid Authorization header" in {
+    val request = new AuthorizationRequest(Map("Authorization" -> Seq("Digest Y2xpZW50X2lkX3ZhbHVlOg==")), Map())
+    request.clientCredential.isDefined shouldBe true
+    request.clientCredential.get.isLeft shouldBe true
+  }
+
+  it should "not fetch if Authorization header is invalid, but client_id and client_secret are valid and present in parms" in {
     val request = new AuthorizationRequest(
       Map("Authorization" -> Seq("fakeheader aaaa")),
       Map("client_id" -> Seq("client_id_value"), "client_secret" -> Seq("client_secret_value"))
     )
-    val Some(c) = request.clientCredential
-    c.clientId should be("client_id_value")
-    c.clientSecret should be(Some("client_secret_value"))
+    request.clientCredential.isDefined shouldBe true
+    request.clientCredential.get.isLeft shouldBe true
   }
 }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationRequestSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/AuthorizationRequestSpec.scala
@@ -7,71 +7,75 @@ class AuthorizationRequestSpec extends FlatSpec {
 
   it should "fetch Basic64" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOmNsaWVudF9zZWNyZXRfdmFsdWU=")), Map())
-    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val Some(c) = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(Some("client_secret_value"))
   }
 
   it should "fetch Basic64 by case insensitive" in {
     val request = new AuthorizationRequest(Map("authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOmNsaWVudF9zZWNyZXRfdmFsdWU=")), Map())
-    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val Some(c) = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(Some("client_secret_value"))
   }
 
   it should "fetch authorization header without colon" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVl")), Map())
-    request.clientCredential.isDefined shouldBe true
-    request.clientCredential.get.isLeft shouldBe true
+    val parsedCred = request.parseClientCredential
+    parsedCred.isDefined shouldBe true
+    parsedCred.get.isLeft shouldBe true
   }
 
   it should "fetch empty client_secret with colon" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOg==")), Map())
-    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val Some(c) = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(None)
   }
 
   it should "not fetch not Authorization key in header" in {
     val request = new AuthorizationRequest(Map("authorizatio" -> Seq("Basic Y2xpZW50X2lkX3ZhbHVlOmNsaWVudF9zZWNyZXRfdmFsdWU=")), Map())
-    request.clientCredential should be(None)
+    request.parseClientCredential should be(None)
   }
 
   it should "not fetch invalid Base64" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Basic basic")), Map())
-    request.clientCredential.isDefined shouldBe true
-    request.clientCredential.get.isLeft shouldBe true
+    val parsedCred = request.parseClientCredential
+    parsedCred.isDefined shouldBe true
+    parsedCred.get.isLeft shouldBe true
   }
 
   it should "fetch parameter" in {
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("client_id_value"), "client_secret" -> Seq("client_secret_value")))
-    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val Some(c) = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(Some("client_secret_value"))
   }
 
   it should "omit client_secret" in {
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("client_id_value")))
-    val Some(c) = request.clientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val Some(c) = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     c.clientId should be("client_id_value")
     c.clientSecret should be(None)
   }
 
   it should "not fetch missing parameter" in {
     val request = new AuthorizationRequest(Map(), Map("client_secret" -> Seq("client_secret_value")))
-    request.clientCredential should be(None)
+    request.parseClientCredential should be(None)
   }
 
   it should "not fetch invalid parameter" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("")), Map())
-    request.clientCredential.isDefined shouldBe true
-    request.clientCredential.get.isLeft shouldBe true
+    val parsedCred = request.parseClientCredential
+    parsedCred.isDefined shouldBe true
+    parsedCred.get.isLeft shouldBe true
   }
 
   it should "not fetch invalid Authorization header" in {
     val request = new AuthorizationRequest(Map("Authorization" -> Seq("Digest Y2xpZW50X2lkX3ZhbHVlOg==")), Map())
-    request.clientCredential.isDefined shouldBe true
-    request.clientCredential.get.isLeft shouldBe true
+    val parsedCred = request.parseClientCredential
+    parsedCred.isDefined shouldBe true
+    parsedCred.get.isLeft shouldBe true
   }
 
   it should "not fetch if Authorization header is invalid, but client_id and client_secret are valid and present in parms" in {
@@ -79,7 +83,8 @@ class AuthorizationRequestSpec extends FlatSpec {
       Map("Authorization" -> Seq("fakeheader aaaa")),
       Map("client_id" -> Seq("client_id_value"), "client_secret" -> Seq("client_secret_value"))
     )
-    request.clientCredential.isDefined shouldBe true
-    request.clientCredential.get.isLeft shouldBe true
+    val parsedCred = request.parseClientCredential
+    parsedCred.isDefined shouldBe true
+    parsedCred.get.isLeft shouldBe true
   }
 }

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
@@ -12,7 +12,8 @@ class ClientCredentialsSpec extends FlatSpec with ScalaFutures with OptionValues
   it should "handle request" in {
     val clientCredentials = new ClientCredentials()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "scope" -> Seq("all")))
-    val f = clientCredentials.handleRequest(request, new MockDataHandler() {
+    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
+    val f = clientCredentials.handleRequest(clientId, request, new MockDataHandler() {
 
       override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
@@ -12,8 +12,8 @@ class ClientCredentialsSpec extends FlatSpec with ScalaFutures with OptionValues
   it should "handle request" in {
     val clientCredentials = new ClientCredentials()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "client_secret" -> Seq("clientSecret1"), "scope" -> Seq("all")))
-    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
-    val f = clientCredentials.handleRequest(clientId, request, new MockDataHandler() {
+    val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val f = clientCredentials.handleRequest(clientCred, request, new MockDataHandler() {
 
       override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
@@ -18,8 +18,8 @@ class ImplicitSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   def handlesRequest(implicitGrant: Implicit, user: String, pass: String, ok: Boolean) = {
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("client"), "username" -> Seq(user), "password" -> Seq(pass), "scope" -> Seq("all")))
-    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
-    val f = implicitGrant.handleRequest(clientId, request, new MockDataHandler() {
+    val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val f = implicitGrant.handleRequest(clientCred, request, new MockDataHandler() {
 
       override def findUser(request: AuthorizationRequest): Future[Option[User]] = {
         val result = request match {

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
@@ -18,7 +18,8 @@ class ImplicitSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   def handlesRequest(implicitGrant: Implicit, user: String, pass: String, ok: Boolean) = {
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("client"), "username" -> Seq(user), "password" -> Seq(pass), "scope" -> Seq("all")))
-    val f = implicitGrant.handleRequest(request, new MockDataHandler() {
+    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
+    val f = implicitGrant.handleRequest(clientId, request, new MockDataHandler() {
 
       override def findUser(request: AuthorizationRequest): Future[Option[User]] = {
         val result = request match {

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
@@ -19,8 +19,8 @@ class PasswordSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   def handlesRequest(password: Password, params: Map[String, Seq[String]]) = {
     val request = new AuthorizationRequest(Map(), params ++ Map("username" -> Seq("user"), "password" -> Seq("pass"), "scope" -> Seq("all")))
-    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
-    val f = password.handleRequest(clientId, request, new MockDataHandler() {
+    val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val f = password.handleRequest(clientCred, request, new MockDataHandler() {
 
       override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
@@ -19,7 +19,8 @@ class PasswordSpec extends FlatSpec with ScalaFutures with OptionValues {
 
   def handlesRequest(password: Password, params: Map[String, Seq[String]]) = {
     val request = new AuthorizationRequest(Map(), params ++ Map("username" -> Seq("user"), "password" -> Seq("pass"), "scope" -> Seq("all")))
-    val f = password.handleRequest(request, new MockDataHandler() {
+    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
+    val f = password.handleRequest(clientId, request, new MockDataHandler() {
 
       override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/RefreshTokenSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/RefreshTokenSpec.scala
@@ -12,7 +12,8 @@ class RefreshTokenSpec extends FlatSpec with ScalaFutures with OptionValues {
   it should "handle request" in {
     val refreshToken = new RefreshToken()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "clinet_secret" -> Seq("clientSecret1"), "refresh_token" -> Seq("refreshToken1")))
-    val f = refreshToken.handleRequest(request, new MockDataHandler() {
+    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
+    val f = refreshToken.handleRequest(clientId, request, new MockDataHandler() {
 
       override def findAuthInfoByRefreshToken(refreshToken: String): Future[Option[AuthInfo[User]]] =
         Future.successful(Some(AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = None, redirectUri = None)))

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/RefreshTokenSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/RefreshTokenSpec.scala
@@ -12,8 +12,8 @@ class RefreshTokenSpec extends FlatSpec with ScalaFutures with OptionValues {
   it should "handle request" in {
     val refreshToken = new RefreshToken()
     val request = new AuthorizationRequest(Map(), Map("client_id" -> Seq("clientId1"), "clinet_secret" -> Seq("clientSecret1"), "refresh_token" -> Seq("refreshToken1")))
-    val clientId = request.clientCredential.fold[Option[String]](None)(_.fold(_ => None, c => Some(c.clientId)))
-    val f = refreshToken.handleRequest(clientId, request, new MockDataHandler() {
+    val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
+    val f = refreshToken.handleRequest(clientCred, request, new MockDataHandler() {
 
       override def findAuthInfoByRefreshToken(refreshToken: String): Future[Option[AuthInfo[User]]] =
         Future.successful(Some(AuthInfo(user = MockUser(10000, "username"), clientId = Some("clientId1"), scope = None, redirectUri = None)))


### PR DESCRIPTION
* The root of this PR stems from this part of the specification: https://tools.ietf.org/html/rfc6749#section-5.2 This section states that in the event a client is authenticating via the “Authorization” header field, then the authorization server MUST respond with a 401 Unauthorized in the event the client does not have access. This validation must occur before any other validations occur since this is an authentication state via a standard header. Only after the authorization has validated - assuming via the Authorization header - can the rest of the processing and validation continue.
* Added some documentation comments on the AuthorizationHandler trait further explaining what a client validation request must do.
* Removed some unnecessary overrides for fetching the clientCrential in the request type case classes as they are unnecessary since they don’t override anything.
* Cleaned up tests to reflect changes for Authorization Header changes, added a few new tests to cover the new case.