### PR TITLE
Pass validated client credential to AuthorizationHandler

### DIFF
--- a/akka-http-oauth2-provider/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
+++ b/akka-http-oauth2-provider/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
@@ -6,9 +6,9 @@ import scala.concurrent.Future
 
 class MockDataHandler extends DataHandler[User] {
 
-  override def validateClient(request: AuthorizationRequest): Future[Boolean] = Future.successful(false)
+  override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] = Future.successful(false)
 
-  override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(None)
+  override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] = Future.successful(None)
 
   override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("", Some(""), Some(""), Some(0L), new Date()))
 

--- a/akka-http-oauth2-provider/src/test/scala/scalaoauth2/provider/OAuth2ProviderSpec.scala
+++ b/akka-http-oauth2-provider/src/test/scala/scalaoauth2/provider/OAuth2ProviderSpec.scala
@@ -35,9 +35,9 @@ class OAuth2ProviderSpec extends WordSpec with Matchers with ScalatestRouteTest 
         Future.successful(Some(accessToken))
       override def findAuthInfoByAccessToken(accessToken: AccessToken): Future[Option[AuthInfo[User]]] =
         Future.successful(someAuthInfo)
-      override def findUser(request: AuthorizationRequest): Future[Option[User]] =
+      override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] =
         Future.successful(Some(user))
-      override def validateClient(request: AuthorizationRequest): Future[Boolean] =
+      override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] =
         Future.successful(true)
       override def getStoredAccessToken(authInfo: AuthInfo[User]): Future[Option[AccessToken]] =
         Future.successful(Some(accessToken))

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/AuthorizationHandler.scala
@@ -59,18 +59,20 @@ trait AuthorizationHandler[U] {
    * secret (common with Public Clients). However, if the registered client has a client secret value the specification
    * requires that a client secret must always be provided and verified for that client ID.
    *
+   * @param maybeCredential client credential parsed from request
    * @param request Request sent by client.
    * @return true if request is a regular client, false if request is a illegal client.
    */
-  def validateClient(request: AuthorizationRequest): Future[Boolean]
+  def validateClient(maybeCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean]
 
   /**
    * Authenticate the user that issued the authorization request.
    * Client credential, Password and Implicit Grant call this method.
    *
+   * @param maybeCredential client credential parsed from request
    * @param request Request sent by client.
    */
-  def findUser(request: AuthorizationRequest): Future[Option[U]]
+  def findUser(maybeCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[U]]
 
   /**
    * Creates a new access token by authorized information.

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/GrantHandler.scala
@@ -77,7 +77,7 @@ class Password extends GrantHandler {
       throw new InvalidRequest("Client credential is required")
     } else {
       val passwordRequest = PasswordRequest(request)
-      handler.findUser(passwordRequest).flatMap { maybeUser =>
+      handler.findUser(maybeValidatedClientCred, passwordRequest).flatMap { maybeUser =>
         val user = maybeUser.getOrElse(throw new InvalidGrant("username or password is incorrect"))
         val scope = passwordRequest.scope
         val authInfo = AuthInfo(user, maybeValidatedClientCred.map(_.clientId), scope, None)
@@ -95,7 +95,7 @@ class ClientCredentials extends GrantHandler {
     val clientCredentialsRequest = ClientCredentialsRequest(request)
     val scope = clientCredentialsRequest.scope
 
-    handler.findUser(clientCredentialsRequest).flatMap { optionalUser =>
+    handler.findUser(maybeValidatedClientCred, clientCredentialsRequest).flatMap { optionalUser =>
       val user = optionalUser.getOrElse(throw new InvalidGrant("client_id or client_secret or scope is incorrect"))
       val authInfo = AuthInfo(user, Some(clientId), scope, None)
 
@@ -139,7 +139,7 @@ class Implicit extends GrantHandler {
     val clientId = maybeValidatedClientCred.getOrElse(throw new InvalidRequest("Client credential is required")).clientId
     val implicitRequest = ImplicitRequest(request)
 
-    handler.findUser(implicitRequest).flatMap { maybeUser =>
+    handler.findUser(maybeValidatedClientCred, implicitRequest).flatMap { maybeUser =>
       val user = maybeUser.getOrElse(throw new InvalidGrant("user cannot be authenticated"))
       val scope = implicitRequest.scope
       val authInfo = AuthInfo(user, Some(clientId), scope, None)

--- a/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
+++ b/scala-oauth2-core/src/main/scala/scalaoauth2/provider/TokenEndpoint.scala
@@ -13,7 +13,7 @@ trait TokenEndpoint {
       maybeCredential.fold(
         invalid => Future.successful(Left(invalid)),
         clientCredential => {
-          handler.validateClient(request).flatMap { isValidClient =>
+          handler.validateClient(Some(clientCredential), request).flatMap { isValidClient =>
             if (!isValidClient) {
               Future.successful(Left(new InvalidClient("Invalid client or client is not authorized")))
             } else {

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ClientCredentialsSpec.scala
@@ -15,7 +15,7 @@ class ClientCredentialsSpec extends FlatSpec with ScalaFutures with OptionValues
     val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     val f = clientCredentials.handleRequest(clientCred, request, new MockDataHandler() {
 
-      override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
+      override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 
       override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("token1", None, Some("all"), Some(3600), new java.util.Date()))
     })

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/ImplicitSpec.scala
@@ -21,7 +21,7 @@ class ImplicitSpec extends FlatSpec with ScalaFutures with OptionValues {
     val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     val f = implicitGrant.handleRequest(clientCred, request, new MockDataHandler() {
 
-      override def findUser(request: AuthorizationRequest): Future[Option[User]] = {
+      override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] = {
         val result = request match {
           case request: ImplicitRequest =>
             for {

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/MockDataHandler.scala
@@ -6,9 +6,9 @@ import scala.concurrent.Future
 
 class MockDataHandler extends DataHandler[User] {
 
-  override def validateClient(request: AuthorizationRequest): Future[Boolean] = Future.successful(false)
+  override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] = Future.successful(false)
 
-  override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(None)
+  override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] = Future.successful(None)
 
   override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("", Some(""), Some(""), Some(0L), new Date()))
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/PasswordSpec.scala
@@ -22,7 +22,7 @@ class PasswordSpec extends FlatSpec with ScalaFutures with OptionValues {
     val clientCred = request.parseClientCredential.fold[Option[ClientCredential]](None)(_.fold(_ => None, c => Some(c)))
     val f = password.handleRequest(clientCred, request, new MockDataHandler() {
 
-      override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
+      override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 
       override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("token1", Some("refreshToken1"), Some("all"), Some(3600), new java.util.Date()))
 

--- a/scala-oauth2-core/src/test/scala/scalaoauth2/provider/TokenEndPointSpec.scala
+++ b/scala-oauth2-core/src/test/scala/scalaoauth2/provider/TokenEndPointSpec.scala
@@ -13,9 +13,9 @@ class TokenEndPointSpec extends FlatSpec with ScalaFutures {
 
   def successfulDataHandler() = new MockDataHandler() {
 
-    override def validateClient(request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
+    override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
 
-    override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
+    override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 
     override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = Future.successful(AccessToken("token1", None, Some("all"), Some(3600), new Date()))
 
@@ -129,7 +129,7 @@ class TokenEndPointSpec extends FlatSpec with ScalaFutures {
 
     val dataHandler = new MockDataHandler() {
 
-      override def validateClient(request: AuthorizationRequest): Future[Boolean] = Future.successful(false)
+      override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] = Future.successful(false)
 
     }
 
@@ -157,9 +157,9 @@ class TokenEndPointSpec extends FlatSpec with ScalaFutures {
 
     def dataHandler = new MockDataHandler() {
 
-      override def validateClient(request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
+      override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
 
-      override def findUser(request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
+      override def findUser(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Option[User]] = Future.successful(Some(MockUser(10000, "username")))
 
       override def createAccessToken(authInfo: AuthInfo[User]): Future[AccessToken] = throw new Exception("Failure")
 
@@ -201,7 +201,7 @@ class TokenEndPointSpec extends FlatSpec with ScalaFutures {
 
     val dataHandler = new MockDataHandler() {
 
-      override def validateClient(request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
+      override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
 
     }
 
@@ -230,7 +230,7 @@ class TokenEndPointSpec extends FlatSpec with ScalaFutures {
 
     val dataHandler = new MockDataHandler() {
 
-      override def validateClient(request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
+      override def validateClient(maybeClientCredential: Option[ClientCredential], request: AuthorizationRequest): Future[Boolean] = Future.successful(true)
 
     }
 


### PR DESCRIPTION
fix #113

We removed `AuthorizationHandler#clientCredential` by #110

But `AuthorizationHandler#validateClient` and `AuthorizationHandler#findUser` may use it.
We needed to pass validated client credential to it.