### PR TITLE
OAuthException description as Exception message

### DIFF
--- a/src/main/scala/scalaoauth2/provider/OAuthException.scala
+++ b/src/main/scala/scalaoauth2/provider/OAuthException.scala
@@ -1,6 +1,6 @@
 package scalaoauth2.provider
 
-abstract class OAuthError(val statusCode: Int, val description: String) extends Exception {
+abstract class OAuthError(val statusCode: Int, val description: String) extends Exception(description) {
 
   def this(description: String) = this(400, description)
 


### PR DESCRIPTION
When writing tests, I found out that the error message aka description in the OAuthException is not mapped to the message of the Exception.
For testing, this would be very benefitial and also for a more detailed error message when using it.

btw: thank you very much for this nice and compact library.