### PR TITLE
add openjdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: scala
 scala:
-  - 2.12.7
+  - 2.12.8
   - 2.11.12
   - 2.13.0-M5
 jdk:
   - oraclejdk8
+  - openjdk11
 notifications:
   webhooks:
     urls:

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ lazy val scalaOAuth2ProviderSettings =
   Defaults.coreDefaultSettings ++
     Seq(
       organization := "com.nulab-inc",
-      scalaVersion := "2.12.7",
-      crossScalaVersions := Seq("2.12.7", "2.11.12", "2.13.0-M5"),
+      scalaVersion := "2.12.8",
+      crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0-M5"),
       scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature"),
       scalacOptions ++= unusedWarnings,
       publishTo := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8


### PR DESCRIPTION
## Motivation

In order to check that it run in the environment of `openjdk11`,
Added setting for travisCI.

https://www.scala-lang.org/2019/01/18/community-build.html