### PR TITLE
use `scalafmtCheckAll`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Coursier cache
         uses: coursier/cache-action@v5
       - name: Build and test
-        run: sbt scalafmtSbtCheck scalafmtCheck test:scalafmtCheck +test
+        run: sbt scalafmtSbtCheck scalafmtCheckAll +test
       - run: rm -rf "$HOME/.ivy2/local" || true


### PR DESCRIPTION
`test:scalafmtCheck` syntax is deprecated

```
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: Test / scalafmtCheck
```

https://github.com/scalameta/sbt-scalafmt/blob/3cc5809c6c6ece5bf85445c96a80f2cb6a60c890/plugin/src/main/scala/org/scalafmt/sbt/ScalafmtPlugin.scala#L60-L63

```scala
    val scalafmtAll = taskKey[Unit](
       "Execute the scalafmt task for all configurations in which it is enabled. " +
        "(By default this means the Compile and Test configurations.)"
```